### PR TITLE
Update to not use short tags

### DIFF
--- a/src/ImpersonateServiceProvider.php
+++ b/src/ImpersonateServiceProvider.php
@@ -24,12 +24,12 @@ class ImpersonateServiceProvider extends ServiceProvider
 
         // Register the @impersonate directive
         Blade::directive('impersonate', function () {
-            return "<? if(Session::has('original_user')): ?>";
+            return "<?php if(Session::has('original_user')): ?>";
         });
 
         // Register the @endimpersonate directive
         Blade::directive('endimpersonate', function () {
-            return "<? endif; ?>";
+            return "<?php endif; ?>";
         });
     }
 


### PR DESCRIPTION
Using short tags creates blade template errors in some cases - best practice to not use them